### PR TITLE
Get the correct username from the page URL, rather than extracting it from HTML

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -13,6 +13,29 @@ const go = () => {
         }
 
         const tryAndGetUserName = () => {
+            /* Firstly, try and get the username from the URL. The URL could be one for the following forms
+              https://front-end.social/@mia/109348973362020954 
+              https://front-end.social/@mia
+              https://hachyderm.io/@mia@front-end.social
+              https://hachyderm.io/@mia@front-end.social/109348973362020954 
+            */ 
+            const host = window.location.host;
+            /* window.location.pathname would be /@mia/109348973362020954 or /@mia */
+            const username = window.location.pathname.split('/')[1];
+            const usernameParts = username.split('@');
+
+            // username contains only one @ - it's a user at the current host
+            if (usernameParts.length === 2) {
+                return `${usernameParts[1]}@${host}`;
+            }
+
+            // username contains two @: it's a remote user
+            if (usernameParts.length === 3) {
+                return `${usernameParts[1]}@${usernameParts[2]}`
+            }
+
+            /** If we haven't been able to identify the host, try and extract it from various parts of the page. */
+
             /* Profile with a moved banner (e.g. https://mastodon.social/@bramus): follow that link */
             const userNewProfile = document.querySelector('.moved-account-banner .button')?.getAttribute('href');
             if (userNewProfile) {

--- a/src/background.js
+++ b/src/background.js
@@ -13,29 +13,6 @@ const go = () => {
         }
 
         const tryAndGetUserName = () => {
-            /* Firstly, try and get the username from the URL. The URL could be one for the following forms
-              https://front-end.social/@mia/109348973362020954 
-              https://front-end.social/@mia
-              https://hachyderm.io/@mia@front-end.social
-              https://hachyderm.io/@mia@front-end.social/109348973362020954 
-            */ 
-            const host = window.location.host;
-            /* window.location.pathname would be /@mia/109348973362020954 or /@mia */
-            const username = window.location.pathname.split('/')[1];
-            const usernameParts = username.split('@');
-
-            // username contains only one @ - it's a user at the current host
-            if (usernameParts.length === 2) {
-                return `${usernameParts[1]}@${host}`;
-            }
-
-            // username contains two @: it's a remote user
-            if (usernameParts.length === 3) {
-                return `${usernameParts[1]}@${usernameParts[2]}`
-            }
-
-            /** If we haven't been able to identify the host, try and extract it from various parts of the page. */
-
             /* Profile with a moved banner (e.g. https://mastodon.social/@bramus): follow that link */
             const userNewProfile = document.querySelector('.moved-account-banner .button')?.getAttribute('href');
             if (userNewProfile) {
@@ -54,6 +31,27 @@ const go = () => {
             /* Message detail, e.g. https://front-end.social/@mia/109348973362020954 and https://bell.bz/@andy/109392510558650993 and https://bell.bz/@andy/109392510558650993 */
             const userFromDetailPage = document.querySelector('.detailed-status .display-name__account')?.innerText;
             if (userFromDetailPage) return userFromDetailPage.substring(1);
+
+            /* Finally, if we didn't manage to get the username from the HTML, try and get the username from the URL. The URL could be one for the following forms
+            https://front-end.social/@mia/109348973362020954 
+            https://front-end.social/@mia
+            https://hachyderm.io/@mia@front-end.social
+            https://hachyderm.io/@mia@front-end.social/109348973362020954 
+            */
+            const host = window.location.host;
+            /* window.location.pathname would be /@mia/109348973362020954 or /@mia */
+            const username = window.location.pathname.split('/')[1];
+            const usernameParts = username.split('@');
+
+            // username contains only one @ - it's a user at the current host
+            if (usernameParts.length === 2) {
+                return `${usernameParts[1]}@${host}`;
+            }
+
+            // username contains two @: it's a remote user
+            if (usernameParts.length === 3) {
+                return `${usernameParts[1]}@${usernameParts[2]}`
+            }
         
             return null;
         };


### PR DESCRIPTION
That should be both more reliable, and stable (particularly when mastodon instances use custom themes, or a new mastodon version changes the HTML).

It also addresses https://github.com/bramus/mastodon-profile-redirect/issues/3: The reason this one isn't working, is because hachyderm doesn't always have the `meta[property="profile:username"]` element on the page.

I have left the previous mechanism to extract the username from the HTML in place, because it might be useful for instances that have changed the URL scheme (e.g. by removing the `@` from the url) although I personally haven't seen any.