### PR TITLE
Fixed profile redirects on new Mastodon versions

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -10,9 +10,16 @@ const go = () => {
 		}
 
 		/* Profile page, e.g. https://fediverse.zachleat.com/@zachleat and https://front-end.social/@mia */
-		const userFromProfilePage = document.querySelector('.account__header .account__header__tabs__name small')?.innerText.substring(1);
+		const userFromProfilePage = document.querySelector('.account__header .account__header__tabs__name small')?.innerText.split('\n');
 		if (userFromProfilePage) {
-			return userFromProfilePage;
+			/* For profile pages on Mastodon v4.2.x */
+			if (userFromProfilePage.length == 1) {
+				return userFromProfilePage[0].substring(1);
+			}
+			/* For profile pages on Mastodon v4.3.x and v4.4.x */
+			else if (userFromProfilePage.length == 3) {
+				return userFromProfilePage[0].substring(1) + userFromProfilePage[1];
+			}
 		}
 
 		// Not a profile page or some markup that is preventing things from happening

--- a/src/content.js
+++ b/src/content.js
@@ -13,9 +13,16 @@ const tryAndGetUserNameFromProfilePage = () => {
 	}
 
 	/* Profile page, e.g. https://fediverse.zachleat.com/@zachleat and https://front-end.social/@mia */
-	const userFromProfilePage = document.querySelector('.account__header .account__header__tabs__name small')?.innerText.substring(1);
+	const userFromProfilePage = document.querySelector('.account__header .account__header__tabs__name small')?.innerText.split('\n');
 	if (userFromProfilePage) {
-		return userFromProfilePage;
+		/* For profile pages on Mastodon v4.2.x */
+		if (userFromProfilePage.length == 1) {
+			return userFromProfilePage[0].substring(1);
+		}
+		/* For profile pages on Mastodon v4.3.x and v4.4.x */
+		else if (userFromProfilePage.length == 3) {
+			return userFromProfilePage[0].substring(1) + userFromProfilePage[1];
+		}
 	}
 
 	// Not a profile page or some markup that is preventing things from happening


### PR DESCRIPTION
- Closes Issue #10

Uses same query selector from the existing exstension but splits the string by new line. As newer versions have invisible text in the HTML element that causes the Mastodon server domain to be present twice separated by new lines. If an older server version is running there's only one element returned if not the array contains three strings. 

For example `userFromProfilePage` from https://mastodon.social/@Mastodon returns:
```javascript
['@Mastodon', '@mastodon.social', 'mastodon.social']
```
The first two elements can be concatenated to redirect the user.